### PR TITLE
fix react types

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "@types/jest": "^29.4.0",
         "@types/node": "20.2.5",
         "@types/nodemailer": "^6.4.7",
-        "@types/react": "18.2.8",
+        "@types/react": "18.2.13",
         "@types/react-dom": "18.0.11",
         "@types/showdown": "^2.0.1",
         "@types/uuid": "^9.0.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
         "skipDefaultLibCheck": true,
         "baseUrl": ".",
         "paths": {
+            "react": ["./node_modules/@types/react"],
             "@api": ["libs/api/src/index.ts"],
             "@auth": ["libs/auth/src/index.ts"],
             "@components": ["libs/components/src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,10 +4182,10 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.2.8":
-  version "18.2.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.8.tgz#a77dcffe4e9af148ca4aa8000c51a1e8ed99e2c8"
-  integrity sha512-lTyWUNrd8ntVkqycEEplasWy2OxNlShj3zqS0LuB1ENUGis5HodmhM7DtCoUGbxj3VW/WsGA0DUhpG6XrM7gPA==
+"@types/react@*", "@types/react@18.2.13":
+  version "18.2.13"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.13.tgz#a98c09bde8b18f80021935b11d2d29ef5f4dcb2f"
+  integrity sha512-vJ+zElvi/Zn9cVXB5slX2xL8PZodPCwPRDpittQdw43JR2AJ5k3vKdgJJyneV/cYgIbLQUwXa9JVDvUZXGba+Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
- chore(deps): bump deps
- fix(deps): revert @types/react to 18.2.8 see discussion at https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65612
- fix(deps): fix ts error error was caused by multiple incompatible versions of react-types @testing-library used its own types but forcing specifying react types in tsconfig.base.json fixed the error
